### PR TITLE
Updated text below 311 button per Hoang’s email

### DIFF
--- a/templates/_layouts/_services311.twig
+++ b/templates/_layouts/_services311.twig
@@ -18,7 +18,7 @@
     </div>
     <div class="md:w-1/2 md:ml-4">
       <a href="tel:+1-510-615-5566" class="block card-grid-button py-5 bg-green-300 text-white hover:text-white hover:bg-green-600 shadow-none"><img src="/assets/img/icon-phone.svg" class="inline h-6 w-auto mr-4">Call 311</a>
-      <div class="mt-2 text-sm font-bold md:text-base md:font-normal">For urgent issues, call us.</div>
+      <div class="mt-2 text-sm font-bold md:text-base md:font-normal">For urgent issues, call <strong><a href="tel:311">311</a></strong> or <strong><a href="tel:1+510-615-5566">(510) 615-5566</a></strong>.</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
> Now, it would also help to amend as follows below that green call button: "For urgent issues, call 311 or (510) 615-5566" that way the long # is in an more prominent/visible location (as few folks scroll all the way down to footer).

Signed-off-by: Christopher Kennedy <chris@onebrightlight.com>