### PR TITLE
Fix Content Builder list styles

### DIFF
--- a/templates/_partials/_content-builder/_tool.twig
+++ b/templates/_partials/_content-builder/_tool.twig
@@ -35,7 +35,7 @@
         <tr>
           {% for col in 1..columns %}
             {% set colAttrib = 'column' ~ col ~ 'Cell' %}
-            <td class="border-green-400 o-6 page-body">{{ attribute(row, colAttrib) }}</td>
+            <td class="border-green-400 o-6 body-text">{{ attribute(row, colAttrib) }}</td>
           {% endfor %}
         </tr>
       {% endfor %}
@@ -54,7 +54,7 @@
       <a id="{{ blockId }}" class="anchor-link"></a>
       <{{ subheading }} class="{{ subheadingClass }}">{{ block.text }}</{{ subheading }}>
     {% case "text" %}
-      <div class="o-6 page-body">
+      <div class="o-6 body-text">
         {{ block.text }}
       </div>
     {% case "table2Columns" %}


### PR DESCRIPTION
Fixes typo in class name of content builder that prevented bulleted and ordered lists from showing their bullets.