### PR TITLE
Add service category descriptions, fix content builder heading links

### DIFF
--- a/config/project.yaml
+++ b/config/project.yaml
@@ -21,6 +21,16 @@ categoryGroups:
         hasUrls: true
         uriFormat: 'services/category/{slug}'
         template: services/_category
+    fieldLayouts:
+      aa57cc98-0a36-4294-a711-d0916c509ae4:
+        tabs:
+          -
+            name: Content
+            sortOrder: 1
+            fields:
+              58eda166-7a65-4fb6-8f7d-c6590b0591ae:
+                required: false
+                sortOrder: 1
   947de11d-3d94-45c2-8565-04542ce0e737:
     name: 'Event Types'
     handle: eventTypes
@@ -32,7 +42,7 @@ categoryGroups:
         hasUrls: false
         uriFormat: null
         template: null
-dateModified: 1573753368
+dateModified: 1574707511
 email:
   fromEmail: $EMAIL_ADDRESS
   fromName: $EMAIL_SENDER_NAME

--- a/templates/_partials/_content-builder/_tool.twig
+++ b/templates/_partials/_content-builder/_tool.twig
@@ -35,7 +35,7 @@
         <tr>
           {% for col in 1..columns %}
             {% set colAttrib = 'column' ~ col ~ 'Cell' %}
-            <td class="border-green-400 o-6 page-body">{{ attribute(row, colAttrib) }}</td>
+            <td class="border-green-400 o-6 body-text">{{ attribute(row, colAttrib) }}</td>
           {% endfor %}
         </tr>
       {% endfor %}
@@ -54,7 +54,7 @@
       <a id="{{ blockId }}" class="anchor-link"></a>
       <{{ subheading }} class="{{ subheadingClass }}">{{ block.text }}</{{ subheading }}>
     {% case "text" %}
-      <div class="o-6 page-body">
+      <div class="o-6 body-text">
         {{ block.text }}
       </div>
     {% case "table2Columns" %}

--- a/templates/_partials/_content-builder/_tool.twig
+++ b/templates/_partials/_content-builder/_tool.twig
@@ -45,7 +45,7 @@
 {% import _self as macro %}
 
 {% for block in entry.contentBuilder.all() %}
-  {% set blockId =  block.text ?? block.heading | kebab ~ '-' ~ block.id ?? block.id %}
+  {% set blockId =  (block.text ?? block.heading) | kebab ~ '-' ~ block.id ?? block.id %}
   {% switch block.type %}
     {% case "heading" %}
       <a id="{{ blockId }}" class="anchor-link"></a>


### PR DESCRIPTION
Resolves an issue with the content builder building out header links without kebab-ing them, adds summary field to service categories.