### PR TITLE
Deprecated code fix in _largeEntryLinks.twig

### DIFF
--- a/templates/_partials/_content-builder/_blocks/_largeEntryLinks.twig
+++ b/templates/_partials/_content-builder/_blocks/_largeEntryLinks.twig
@@ -2,7 +2,7 @@
   <a class="anchor-link" id="{{ blockId }}"></a>
   <{{ heading }} class="{{ headingClass }}">{{ block.heading }}</{{ heading }}>
   <div class="card-grid grid-equal-height">
-    {% for entry in block.entries %}
+    {% for entry in block.entries.all() %}
       {% include '_partials/_elements/_title-cards.twig' with {
         title: entry.title,
         url: entry.url,


### PR DESCRIPTION
Resolves deprecated code from #37 