### PR TITLE
Set warmCacheAutomatically to `false`

### DIFF
--- a/config/blitz.php
+++ b/config/blitz.php
@@ -120,7 +120,7 @@ return [
     //'clearCacheAutomatically' => true,
 
     // Whether the cache should automatically be warmed after clearing.
-    //'warmCacheAutomatically' => true,
+    'warmCacheAutomatically' => false,
 
     // Whether the cache should automatically be refreshed after a global set is updated.
     //'refreshCacheAutomaticallyForGlobals' => true,


### PR DESCRIPTION
Per the Blitz docs:

[3:28 PM] Kennedy, Christopher

from the blitz docs:

```
Warm Cache Automatically #

Whether the cache should automatically be warmed after clearing. With this setting enabled, Blitz will create a queue job to automatically visit pages whose cache has been cleared in the background. Disabling this setting may make sense if your site is very large and has many related elements.```